### PR TITLE
[#121 fix] : Fixed duplicate user instances in search results

### DIFF
--- a/lib/controllers/Authentication/user_controller.dart
+++ b/lib/controllers/Authentication/user_controller.dart
@@ -137,7 +137,7 @@ class UserDataController extends ChangeNotifier {
   }
 
   Future<void> searchUsersByNameAndUserName(String searchString) async {
-    List<User> users = [];
+    Set<User> users = {};
     if (searchString.isEmpty || searchString.length < 3) {
       printInfo(info: "Empty string");
       searchedUsers = [];
@@ -158,7 +158,10 @@ class UserDataController extends ChangeNotifier {
     for (var index = 0; index < searchUserResponse.docs.length; index++) {
       var doc = searchUserResponse.docs[index].data();
       User foundUser = User.fromMap(doc);
-      users.add(foundUser);
+      if(!users.contains(foundUser)){
+        users.add(foundUser);
+      }
+
     }
 
     endString = username.substring(0, username.length - 1) +
@@ -171,10 +174,14 @@ class UserDataController extends ChangeNotifier {
     for (var index = 0; index < searchUserResponse.docs.length; index++) {
       var doc = searchUserResponse.docs[index].data();
       User foundUser = User.fromMap(doc);
-      users.add(foundUser);
+      if(!users.contains(foundUser)){
+        users.add(foundUser);
+      }
     }
 
-    searchedUsers = users;
+    printInfo(info:"set of searched users : ${users.length}");
+
+    searchedUsers = users.toList();
     printInfo(info: "Number of users found : ${searchedUsers.length}");
     notifyListeners();
   }

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -1,8 +1,6 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
-
 import 'package:wave/utils/enums.dart';
 
 class User {
@@ -150,46 +148,11 @@ class User {
   }
 
   @override
-  bool operator ==(covariant User other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) return true;
-
-    return other.verified == verified &&
-        other.name == name &&
-        other.email == email &&
-        listEquals(other.following, following) &&
-        listEquals(other.followers, followers) &&
-        listEquals(other.posts, posts) &&
-        other.displayPicture == displayPicture &&
-        other.bio == bio &&
-        other.url == url &&
-        other.id == id &&
-        other.username == username &&
-        listEquals(other.stories, stories) &&
-        listEquals(other.blocked, blocked) &&
-        other.coverPicture == coverPicture &&
-        listEquals(other.savedPosts, savedPosts) &&
-        listEquals(other.messages, messages) &&
-        other.account_type == account_type;
+    return other is User && other.id == id;
   }
 
   @override
-  int get hashCode {
-    return verified.hashCode ^
-        name.hashCode ^
-        email.hashCode ^
-        following.hashCode ^
-        followers.hashCode ^
-        posts.hashCode ^
-        displayPicture.hashCode ^
-        bio.hashCode ^
-        url.hashCode ^
-        id.hashCode ^
-        username.hashCode ^
-        stories.hashCode ^
-        blocked.hashCode ^
-        coverPicture.hashCode ^
-        savedPosts.hashCode ^
-        messages.hashCode ^
-        account_type.hashCode;
-  }
+  int get hashCode => id.hashCode;
 }


### PR DESCRIPTION
- Simplified the equality check in the User class to use only the unique ID.
- Updated the `==` operator and `hashCode` method for efficiency.
- Ensured the Set<User> correctly identifies and excludes duplicate instances based on user ID.
 
   This PR closes #121  