### PR TITLE
[#146 feat] : save post ID in user's posts array upon post creation

### DIFF
--- a/lib/controllers/Authentication/user_controller.dart
+++ b/lib/controllers/Authentication/user_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -207,10 +208,22 @@ class UserDataController extends ChangeNotifier {
       String? bio,
       String? fcmToken,
       String? username,
-      List<dynamic>? posts,
+      String? newPostId,
       CroppedFile? coverPicture,
       CroppedFile? displayPicture}) async* {
     // First, update the user's text data
+    if (newPostId != null) {
+      // user has posted recently
+      await FirebaseFirestore.instance.runTransaction((transaction) async {
+        // Add post ID to the user's posts array
+        transaction.update(Database.userDatabase.doc(user!.id), {
+          'posts': FieldValue.arrayUnion([newPostId])
+        });
+      });
+      user = await UserData.getUser(userID: user!.id);
+      notifyListeners();
+    }
+
     CustomResponse customResponse = await UserData.updateUser(
         userId: user!.id,
         fcmToken: fcmToken ?? user!.fcmToken,

--- a/lib/view/screens/CreatePostScreen/create_post_screen.dart
+++ b/lib/view/screens/CreatePostScreen/create_post_screen.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:firebase_auth/firebase_auth.dart' as fb;
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:provider/provider.dart';
 import 'package:wave/controllers/Authentication/user_controller.dart';
 import 'package:wave/controllers/PostController/create_post_controller.dart';
+import 'package:wave/models/response_model.dart';
 import 'package:wave/models/user_model.dart';
 import 'package:wave/utils/constants/custom_colors.dart';
 import 'package:wave/utils/constants/custom_fonts.dart';
@@ -218,13 +221,8 @@ class CreatePostScreen extends StatelessWidget {
                                       fb.FirebaseAuth.instance.currentUser!.uid,
                                   caption: captionController.text);
                               if (res.responseStatus) {
-                                List<dynamic> currentPosts =
-                                    userDataController.user!.posts;
-                                currentPosts.add(res.response.toString());
-                                userDataController.updateProfile(
-                                    posts: currentPosts);
                                 postController.resetController();
-                                Get.showSnackbar(const GetSnackBar(
+                                 Get.showSnackbar(const GetSnackBar(
                                   duration: Duration(seconds: 2),
                                   backgroundColor: Colors.green,
                                   borderRadius: 5,
@@ -232,6 +230,22 @@ class CreatePostScreen extends StatelessWidget {
                                   message:
                                       "Post will be visible in a few minutes",
                                 ));
+                                StreamSubscription<CustomResponse>? sub;
+                                sub = userDataController
+                                    .updateProfile(
+                                        newPostId: res.response.toString())
+                                    .listen(
+                                  (customRes) {
+                                    if (customRes.responseStatus) {
+                                      "Modified post list".printInfo();
+                                    }
+                                  },
+                                  onDone: () {
+                                    sub!.cancel();
+                                  },
+                                );
+
+                               
                               } else {
                                 Get.showSnackbar(GetSnackBar(
                                   backgroundColor: CustomColor.errorColor,


### PR DESCRIPTION
- Updated the user model to include a 'posts' array for storing post IDs.
- Implemented functionality to add the post ID to the 'posts' array in the user document when a new post is created.
- Utilized Firestore transactions to ensure atomicity and consistency.

This ensures that each user maintains a list of their post IDs for easy reference and retrieval.

This PR closes #146 